### PR TITLE
Add more fields to HAPI output

### DIFF
--- a/info_template.json
+++ b/info_template.json
@@ -16,6 +16,14 @@
       "units": null,
       "description": "Path to jp2 image",
       "fill": null
+    },
+    {
+      "name": "path",
+      "type": "string",
+      "length": 255,
+      "units": null,
+      "description": "Relative path to image file, excludes server url",
+      "fill": null
     }
   ]
 }

--- a/info_template.json
+++ b/info_template.json
@@ -24,6 +24,48 @@
       "units": null,
       "description": "Relative path to image file, excludes server url",
       "fill": null
+    },
+    {
+      "name": "refPixelX",
+      "type": "double",
+      "units": null,
+      "description": "X coordinate of reference pixel",
+      "fill": null
+    },
+    {
+      "name": "refPixelY",
+      "type": "double",
+      "units": null,
+      "description": "Y coordinate of reference pixel",
+      "fill": null
+    },
+    {
+      "name": "scale",
+      "type": "double",
+      "units": null,
+      "description": "Image scale in arcseconds/pixel",
+      "fill": null
+    },
+    {
+      "name": "width",
+      "type": "integer",
+      "units": null,
+      "description": "Image width in pixels",
+      "fill": null
+    },
+    {
+      "name": "height",
+      "type": "integer",
+      "units": null,
+      "description": "Image height in pixels",
+      "fill": null
+    },
+    {
+      "name": "rotation",
+      "type": "double",
+      "units": null,
+      "description": "Image rotation in degrees",
+      "fill": null
     }
   ]
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ requests==2.31.0
 SQLAlchemy==2.0.22
 typing_extensions==4.8.0
 urllib3==2.0.7
+sunpy==5.1.1

--- a/src/db.py
+++ b/src/db.py
@@ -58,7 +58,7 @@ class DataRow(_Base):
         # Special case when "Time" is the only parameter
         if len(columns) == 1 and columns[0] == "Time":
             return self.date.strftime(DATE_FORMAT)
-        _columns = list(map(lambda x: getattr(self, x), columns))
+        _columns = list(map(lambda x: str(getattr(self, x)), columns))
         _columns.insert(0, self.date.strftime(DATE_FORMAT))
         return ",".join(_columns)
 

--- a/src/db.py
+++ b/src/db.py
@@ -2,7 +2,7 @@ import os
 from datetime import datetime
 from typing import Iterable
 
-from sqlalchemy import create_engine, Integer, String, DateTime, select, Select, func
+from sqlalchemy import create_engine, Integer, String, DateTime, select, Select, func, Float
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, Session
 from hvpy import DataSource
 
@@ -35,14 +35,24 @@ class DataRow(_Base):
     filename: Mapped[str] = mapped_column(String(255))
     date: Mapped[datetime] = mapped_column(DateTime)
     sourceId: Mapped[int] = mapped_column(Integer)
+    refPixelX: Mapped[float] = mapped_column(Float)
+    refPixelY: Mapped[float] = mapped_column(Float)
+    scale: Mapped[float] = mapped_column(Float)
+    width: Mapped[int] = mapped_column(Integer)
+    height: Mapped[int] = mapped_column(Integer)
+    CROTA1: Mapped[float] = mapped_column(Float)
 
     @property
     def url(self):
         return f"{HOSTNAME}{self.filepath}/{self.filename}"
-    
+
     @property
     def path(self):
         return f"{self.filepath}/{self.filename}"
+
+    @property
+    def rotation(self):
+        return self.CROTA1
 
     def to_csv(self, columns: list[str]) -> str:
         # Special case when "Time" is the only parameter

--- a/src/db.py
+++ b/src/db.py
@@ -39,6 +39,10 @@ class DataRow(_Base):
     @property
     def url(self):
         return f"{HOSTNAME}{self.filepath}/{self.filename}"
+    
+    @property
+    def path(self):
+        return f"{self.filepath}/{self.filename}"
 
     def to_csv(self, columns: list[str]) -> str:
         # Special case when "Time" is the only parameter

--- a/src/hapi.py
+++ b/src/hapi.py
@@ -49,7 +49,7 @@ if __name__ == "__main__":
         help="Start of query range",
     )
     parser.add_argument(
-        "--stop", required=True, type=datetime.fromisoformat, help="Stop of query range"
+        "--stop", required=True, type=parse_date, help="Stop of query range"
     )
     args = parser.parse_args()
     parameters = args.parameters.split(",")

--- a/src/hapi.py
+++ b/src/hapi.py
@@ -6,6 +6,7 @@ to be served by the generic HAPI server.
 from argparse import ArgumentParser, RawDescriptionHelpFormatter
 from datetime import datetime
 from typing import Iterable
+from sunpy.time import parse_time
 
 from db import HAPIDataset, DataRow
 
@@ -27,6 +28,8 @@ def get_data(
     rows = ds.Get(start, stop)
     return Result(rows, parameters)
 
+def parse_date(date: str) -> datetime:
+    return parse_time(date).datetime
 
 if __name__ == "__main__":
     parser = ArgumentParser(
@@ -42,7 +45,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--start",
         required=True,
-        type=datetime.fromisoformat,
+        type=parse_date,
         help="Start of query range",
     )
     parser.add_argument(


### PR DESCRIPTION
Adds the following fields as HAPI parameters:
| parameter | description |
|-----------|-------------|
| path | Path to image without server prefix |
| refPixelX | reference pixel coord |
| refPixelY | reference pixel coord |
| scale | image scale |
| width | image width |
| height | image height |
| rotation | image rotation |
